### PR TITLE
Remove a/b/c/d suffixed manamojis, add brackets where missing

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,6 @@
       "license": "Apache-2.0",
       "dependencies": {
         "jsdom": "25.0.1",
-        "svg-parser": "2.0.4",
         "tsx": "4.19.2"
       },
       "devDependencies": {
@@ -8158,12 +8157,6 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
-    },
-    "node_modules/svg-parser": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/svg-parser/-/svg-parser-2.0.4.tgz",
-      "integrity": "sha512-e4hG1hRwoOdRb37cIMSgzNsxyzKfayW6VOflrwvR+/bzrkyxY/31WkbgnQpgtrNp1SdpJvpUAGTa/ZoiPNDuRQ==",
-      "license": "MIT"
     },
     "node_modules/symbol-tree": {
       "version": "3.2.4",

--- a/package.json
+++ b/package.json
@@ -31,7 +31,6 @@
   "homepage": "https://github.com/jimbojw/manamoji-css",
   "dependencies": {
     "jsdom": "25.0.1",
-    "svg-parser": "2.0.4",
     "tsx": "4.19.2"
   },
   "devDependencies": {

--- a/src/preamble.css
+++ b/src/preamble.css
@@ -45,21 +45,25 @@
   }
 
   &:where(
-      [data-manamoji~="100A" i],
-      [data-manamoji~="100B" i],
-      [data-manamoji~="1000000A" i],
-      [data-manamoji~="1000000B" i],
-      [data-manamoji~="1000000C" i],
-      [data-manamoji~="1000000D" i],
+      [data-manamoji~="{CHAOS}" i],
       [data-manamoji~="CHAOS" i],
+      [data-manamoji~="{D}" i],
       [data-manamoji~="D" i],
+      [data-manamoji~="{E}" i],
       [data-manamoji~="E" i],
+      [data-manamoji~="{H}" i],
       [data-manamoji~="H" i],
+      [data-manamoji~="{HR}" i],
       [data-manamoji~="HR" i],
+      [data-manamoji~="{HW}" i],
       [data-manamoji~="HW" i],
+      [data-manamoji~="{L}" i],
       [data-manamoji~="L" i],
+      [data-manamoji~="{P}" i],
       [data-manamoji~="P" i],
+      [data-manamoji~="{PW}" i],
       [data-manamoji~="PW" i],
+      [data-manamoji~="{TK}" i],
       [data-manamoji~="TK" i]
     )::before {
     --_shadow-color: transparent;


### PR DESCRIPTION
Investigated using a programmatic method to determine which symbols ought to have a shadow. Unfortunately, the SVG files are inconvenient. Many include a background circle, but some use a path. There did not seem to be a simple, principled way to determine which ought to have a background shadow.